### PR TITLE
Security: Dockerfile updated to Focal due to imminent EOL of Bionic.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
-FROM ubuntu:bionic AS builder
+FROM ubuntu:focal AS builder
 WORKDIR /cow
-RUN apt-get update && apt-get install -qy open-cobol
-RUN apt-get install -qy apache2 libcob1 build-essential curl libffi-dev libffi6 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 curl
-RUN apt-get install -qy haskell-platform
-RUN apt-get install -qy vim
+RUN apt update
+RUN apt full-upgrade -qy
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Madrid
+RUN apt install -qy tzdata
+
+RUN apt install -qy apt-utils open-cobol apache2 libcob4 build-essential curl libffi-dev libffi7 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 curl haskell-platform neovim
 RUN yes | curl --proto '=https' --tlsv1.2 -ksSf https://get-ghcup.haskell.org | sh
 COPY CHADstack2.cabal .
+COPY downhill.sh .
 COPY app ./app
 RUN /root/.ghcup/bin/cabal build
 
@@ -22,7 +27,7 @@ COPY downhill.sh downhill.sh
 
 RUN /root/.cargo/bin/cargo chadr -- --version
 RUN /root/.cargo/bin/cargo chadr -- chad
-RUN ./downhill.sh
+RUN cobc -Wall -x -free cow.cbl cowtemplate.cbl `ls -d controllers/*` -o the.cow
 RUN /root/.cargo/bin/cargo chadr -- link
 
 EXPOSE 80
@@ -30,7 +35,7 @@ ENTRYPOINT ["./run"]
 CMD [ "bash" ]
 
 # FROM haskell:buster
-# RUN apt-get update && apt-get install -qy curl apache2 libcob4 haskell-platform
+# RUN apt update && apt install -qy curl apache2 libcob4 haskell-platform
 # COPY --from=builder /cow /cow
 # RUN curl -o Cabal.tar.gz https://downloads.haskell.org/~cabal/Cabal-3.8.1.0/Cabal-3.8.1.0.tar.gz
 # RUN mkdir /cabal


### PR DESCRIPTION
Yo, so listen up, peeps! 

**We gotta make sure that our CHADstack is hella secure**, _even during the build stage_, ya feel me? Coz Ubuntu Bionic's gonna end standard support in June 2023, and that could be hella risky, you know what I'm sayin'? But, obvs, we don't wanna get caught up in a dependency hell that breaks all our future builds either, right?

So, here's the deal. We should jump to focal at least in the Dockerfile, but I reckon 22.04 is the real MVP at this point, you know what I mean? That way, we can always install the latest LTS, just like it says on DockerHub. Easy peasy. **Saaadly... :( only Ubuntu 20.04 seems functional at this point but we have support up to 04/25! 🚨** 

Oh, and check this out, fam. We can avoid that pesky input freeze waiting for an interactive action that is not possible by setting DEBIAN_FRONTEND=noninteractive and installing tzdata with -qy. I know there's probably a better way, but this is good enough for now. Stupid Ubuntu mate...

Anyway, this Dockerfile uses an updated support for opencobol and 'libffi.so.7' that doesn't use a symlink hack. I'm having a bit of trouble trying to bump up-to-date the versions, but it seems to be working... fingers crossed!

Hope that helps! Let me know if you have any questions or want more explanation on any parts.

PD: works on my machine... also neovim was added instead of vim... 

![image](https://user-images.githubusercontent.com/47398995/231563690-51f39d46-ca9d-40f3-bce7-f7e3deaaebe7.png)

PD2: i'm just joking... if you want a "normal PR"

_"The current Ubuntu Bionic version will end standard support in June 2023, making it a security risk for our CHADstack build. Upgrading to the latest LTS version of Ubuntu, such as Focal or even 22.04, will ensure a more secure build. Additionally, the newer versions will allow for an updated RUST, which is worth the extra time investment. Our updated Dockerfile includes support for OpenCobol and 'libffi.so.7' without resorting to symlink hacks. Let's make sure our CHADstack is up-to-date and secure by using the latest Ubuntu version."_
